### PR TITLE
remove profile default, causing AWS to look for default profile file

### DIFF
--- a/src/AwsPollyFileConversionProvider.php
+++ b/src/AwsPollyFileConversionProvider.php
@@ -32,13 +32,11 @@ class AwsPollyFileConversionProvider
     public function __construct($pollyClient = null, $s3Client = null, $outputDir = 'alternates', $pollyFormat = 'mp3')
     {
         $this->pollyClient = new PollyClient([
-            'profile' => 'default',
             'version' => '2016-06-10',
             'region' => 'us-east-1'
         ]);
 
         $this->s3Client = new S3Client([
-            'profile' => 'default',
             'region' => 'us-east-1',
             'version' => '2006-03-01'
         ]);


### PR DESCRIPTION
Remove profile => default. This was causing AWS PHP SDK to look for the actual AWS credentials in the user folder.
this was an issue because it is suppose to look for env variables first and with this line it was not looking at all.
https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html