### PR TITLE
remove getting errors from DomDocument and restructure formatting of DomDocument

### DIFF
--- a/src/SsmlCreator.php
+++ b/src/SsmlCreator.php
@@ -53,15 +53,12 @@ class SsmlCreator
 
     public function buildSsmlText($text)
     {
-        $preCleanedHtml = $this->cleanUpBeforeDomDoc($text);
-        $strippedHtml = $this->stripHTML($preCleanedHtml);
+        $strippedHtml = $this->stripHTML($text);
         $html = new DOMDocument();
         libxml_use_internal_errors(true);
         $html->loadHTML($strippedHtml);
-        $data['errors'] = libxml_get_errors();
-
-        // remove doctype
-        $html->removeChild($html->doctype);
+        $html = $this->cleanUpDomDoc($html);
+        // $data['errors'] = libxml_get_errors();
 
         $html = $this->setupBaseSSML($html);
 
@@ -262,11 +259,7 @@ class SsmlCreator
 
     }
 
-    private function cleanUpBeforeDomDoc($html) {
-
-        $dom = new DOMDocument();
-        libxml_use_internal_errors(true);
-        $dom->loadHTML($html);
+    private function cleanUpDomDoc($dom) {
 
         // remove doctype
         $dom->removeChild($dom->doctype);
@@ -278,7 +271,7 @@ class SsmlCreator
             $head->parentNode->removeChild($head);
         }
 
-        return $dom->saveHTML();
+        return $dom;
     }
 
 }


### PR DESCRIPTION
This gets rid of getting errors from DomDocument. This is actually important because if there are any errors. We will throw out the Task/AlternateFile even if it did process. So what if we get an error? When we send the SSML through to AWS. [We try to catch errors there](https://github.com/cidilabs/aws-polly/blob/master/src/AwsPollyFileConversionProvider.php#L100). This is the place that is more important because if there is an error with the SSML it will either show in the logs on the server (in general from DomDocument) or from whatever error is returned from aws. This lets files with weird html finish because as of right now html from abbyy is not finishing conversion because of this. 